### PR TITLE
Add Weltkindertag as public holiday for Thüringen on 20.9

### DIFF
--- a/packages/locales/germany/src/locale/holiday-names.ts
+++ b/packages/locales/germany/src/locale/holiday-names.ts
@@ -21,4 +21,5 @@ export enum HolidayName {
     PFINGSTSONNTAG = "Pfingstsonntag",
     BUSS_UND_BETTAG = "Buß- und Bettag",
     WELTFRAUENTAG = "Weltfrauentag",
+    WELTKINDERTAG = "Weltkindertag",
 }

--- a/packages/locales/germany/src/locale/th.state-locale.ts
+++ b/packages/locales/germany/src/locale/th.state-locale.ts
@@ -29,6 +29,14 @@ export class THStateLocale extends AbstractLocale {
                     new LegislationTag(this.legislation),
                 ],
             },
+            {
+                name: HolidayName.WELTKINDERTAG,
+                date: new RecurringDate(20, 8),
+                tags: [
+                    new TypeTag(TypeTagValue.PUBLIC),
+                    new LegislationTag(this.legislation),
+                ],
+            },
         ]);
     }
 }


### PR DESCRIPTION
Since 2019 Thüringen introduced a new public holiday: Weltkindertag on 20.9 each year. This pull request adds the new public holiday.

Source: https://www.mdr.de/thueringen/kindertag-feiertag-thueringen-100.html