### PR TITLE
Add special public holiday for berlin 2020

### DIFF
--- a/packages/locales/germany/src/locale/be.state-locale.ts
+++ b/packages/locales/germany/src/locale/be.state-locale.ts
@@ -30,6 +30,15 @@ export class BEStateLocale extends AbstractLocale {
                     new TypeTag(TypeTagValue.PUBLIC),
                     new LegislationTag(this.legislation),   // not added to this document yet - pending
                 ],
+            }, {
+                name: HolidayName.TAG_DER_BEFREIUNG,
+                date: NonRecurringDate.forPredicate(8, 4, (year) => {
+                    return year === 2020; // only applies for 8.5.2020
+                }),
+                tags: [
+                    new TypeTag(TypeTagValue.PUBLIC),
+                    new LegislationTag(this.legislation),   // not added to this document yet - pending
+                ],
             },
         ]);
     }

--- a/packages/locales/germany/src/locale/holiday-names.ts
+++ b/packages/locales/germany/src/locale/holiday-names.ts
@@ -22,4 +22,5 @@ export enum HolidayName {
     BUSS_UND_BETTAG = "Buß- und Bettag",
     WELTFRAUENTAG = "Weltfrauentag",
     WELTKINDERTAG = "Weltkindertag",
+    TAG_DER_BEFREIUNG = "Tag der Befreiung",
 }


### PR DESCRIPTION
Add Tag der Befreiung for Berlin as a public holiday that occurred once on 8.5.2020.