### PR TITLE
First and second Christmas day should only be public holiday but not special surcharge day

### DIFF
--- a/packages/locales/germany/src/locale/common-state-holiday-definitions.ts
+++ b/packages/locales/germany/src/locale/common-state-holiday-definitions.ts
@@ -79,7 +79,6 @@ export const COMMON_STATE_HOLIDAY_DEFINITIONS = (legislation: Legislation): IHol
         name: HolidayName.ERSTER_WEIHNACHTSFEIERTAG,
         date: new RecurringDate(25, 11),
         tags: [
-            new SpecialSurchargeDayTag(),
             new TypeTag(TypeTagValue.PUBLIC),
             new LegislationTag(legislation),
         ],
@@ -88,7 +87,6 @@ export const COMMON_STATE_HOLIDAY_DEFINITIONS = (legislation: Legislation): IHol
         name: HolidayName.ZWEITER_WEIHNACHTSFEIERTAG,
         date: new RecurringDate(26, 11),
         tags: [
-            new SpecialSurchargeDayTag(),
             new TypeTag(TypeTagValue.PUBLIC),
             new LegislationTag(legislation),
         ],


### PR DESCRIPTION
Currently 25.12 and 26.12 are both considered as public holiday and special surcharge day.

We expected they are only public holiday.