### PR TITLE
fix: correctly calculate buß & betttag

### DIFF
--- a/packages/locales/germany/src/locale/sn.state-locale.ts
+++ b/packages/locales/germany/src/locale/sn.state-locale.ts
@@ -33,15 +33,11 @@ export class SNStateLocale extends AbstractLocale {
             },
             {
                 name: HolidayName.BUSS_UND_BETTAG,
-                date: PeriodicInYearDate.withResolver((year) => {
-                    const date = moment({
-                        day: 23,
-                        month: 10,
-                        year,
-                    });
-
-                    // get the Wednesday before the 23rd November (i.e. the preceding Wednesday)
-                    return date.day(date.day() >= 3 ? 3 : -4);
+                date: PeriodicInYearDate.withResolver((year: number) => {
+                    const christmasDay = moment(new Date(year, 11, 25));
+                    const adjustment = christmasDay.day() == 0 ? -7: 0; // if Christmas is a Sunday, we need to go back one week further
+                    const adventSunday = christmasDay.day(-21 + adjustment);
+                    return adventSunday.subtract(11, "days"); // Buß und Bettag is 11 days before first advent sunday
                 }),
                 tags: [
                     new TypeTag(TypeTagValue.PUBLIC),


### PR DESCRIPTION
The current calculation does not work correctly. It outputs a wrong date for 2022.

The calculation is now corrected and based on the first advent Sunday.

https://www.rechner.club/feiertage/buss-und-bettag-berechnen